### PR TITLE
Fix trailing whitespace bug causing "BAD Could not parse command" usi…

### DIFF
--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -96,7 +96,8 @@ class Command(object):
         self.expected_size = 0
 
     def __repr__(self):
-        return '%s %s%s %s' % (self.tag, self.prefix, self.name, ' '.join(self.args))
+        return '%s %s%s%s%s' % (self.tag, self.prefix, self.name,
+                                ' ' if self.args else '', ' '.join(self.args))
 
     def close(self, line, result):
         self.append_to_resp(line, result=result)


### PR DESCRIPTION
…ng IDLE on GMail.

Hi, the IDLE example in the README isn't working against GMail - gives a "BAD Could not parse command". Comparing with using vanilla python imaplib, it seems GMail needs "<tag> IDLE\r\n" rather than "<tag> IDLE \r\n". Just needs a tweak to Command.__repr__ and it works. Thanks for the hard work on the library!