### PR TITLE
[fix] adding a correct init file

### DIFF
--- a/aioimaplib/__init__.py
+++ b/aioimaplib/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#    aioimaplib : an IMAPrev4 lib using python asyncio
+#    Copyright (C) 2016  Bruno Thomas
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .aioimaplib import *


### PR DESCRIPTION
that way we do: `import aioimaplib` instead of `from aioimaplib import aioimaplib` to achieve the correct result, because the `__init__.py` file was empty, nothing was imported at the module level.