### PR TITLE
fetch timeout param fix

### DIFF
--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -608,7 +608,7 @@ class IMAP4(object):
 
     @asyncio.coroutine
     def fetch(self, message_set, message_parts):
-        return (yield from self.protocol.fetch(message_set, message_parts, self.timeout))
+        return (yield from self.protocol.fetch(message_set, message_parts, timeout=self.timeout))
 
     @asyncio.coroutine
     def idle(self):


### PR DESCRIPTION
Error in line 611 return `(yield from self.protocol.fetch(message_set, message_parts, self.timeout))`
Third param is by_uid. timeout is fourth param