### PR TITLE
[refactor] Move line's cleanup closer to its usage

### DIFF
--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -304,7 +304,7 @@ class IMAP4ClientProtocol(asyncio.Protocol):
             current_cmd.append_to_resp(line)
             return current_cmd
         elif line.startswith('*'):
-            return self._untagged_response(line.replace('* ', ''))
+            return self._untagged_response(line)
         elif line.startswith('+'):
             self._continuation(line)
         else:
@@ -494,6 +494,7 @@ class IMAP4ClientProtocol(asyncio.Protocol):
             yield from self.state_condition.wait_for(lambda: state_re.match(self.state))
 
     def _untagged_response(self, line):
+        line = line.replace('* ', '')
         if self.pending_sync_command is not None:
             self.pending_sync_command.append_to_resp(line)
             command = self.pending_sync_command


### PR DESCRIPTION
There was only one line's replacement left in handle_line()
To move it in the only method that uses it allows a more normalized
(and therefore less surprising) usage of line in handle_line()