### PR TITLE
quote password properly in IMAP dialog

### DIFF
--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -93,6 +93,19 @@ Commands = {
 Response = namedtuple('Response', 'result lines')
 
 
+# copied from https://github.com/mjs/imapclient (imapclient/imapclient.py), 3-clause BSD license
+def _quote(arg):
+    if isinstance(arg, str):
+        arg = arg.replace('\\', '\\\\')
+        arg = arg.replace('"', '\\"')
+        q = '"'
+    else:
+        arg = arg.replace(b'\\', b'\\\\')
+        arg = arg.replace(b'"', b'\\"')
+        q = b'"'
+    return q + arg + q
+
+
 class Command(object):
     def __init__(self, name, tag, *args, prefix=None, untagged_resp_name=None, loop=asyncio.get_event_loop(), timeout=None):
         self.name = name
@@ -404,7 +417,7 @@ class IMAP4ClientProtocol(asyncio.Protocol):
     @asyncio.coroutine
     def login(self, user, password):
         response = yield from self.execute(
-            Command('LOGIN', self.new_tag(), user, '"%s"' % password, loop=self.loop))
+            Command('LOGIN', self.new_tag(), user, '%s' % _quote(password), loop=self.loop))
 
         if 'OK' == response.result:
             self.state = AUTH

--- a/aioimaplib/tests/test_aioimaplib.py
+++ b/aioimaplib/tests/test_aioimaplib.py
@@ -370,6 +370,19 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
         self.assertTrue(imap_client.has_capability('UIDPLUS'))
 
     @asyncio.coroutine
+    def test_login_with_special_characters(self):
+        imap_client = aioimaplib.IMAP4(port=12345, loop=self.loop, timeout=3)
+        yield from asyncio.wait_for(imap_client.wait_hello_from_server(), 2)
+
+        result, data = yield from imap_client.login('user', 'pass"word')
+
+        self.assertEquals(aioimaplib.AUTH, imap_client.protocol.state)
+        self.assertEqual('OK', result)
+        self.assertEqual('LOGIN completed', data[-1])
+        self.assertTrue(imap_client.has_capability('IDLE'))
+        self.assertTrue(imap_client.has_capability('UIDPLUS'))
+
+    @asyncio.coroutine
     def test_login_twice(self):
         with self.assertRaises(aioimaplib.Error) as expected:
             imap_client = yield from self.login_user('user', 'pass')


### PR DESCRIPTION
The actual quoting code was copied from https://github.com/mjs/imapclient
(imapclient/imapclient.py) and used under the 3-clause BSD license.