### PR TITLE
Quote password (with tests)

### DIFF
--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -93,8 +93,12 @@ Commands = {
 Response = namedtuple('Response', 'result lines')
 
 
-# copied from https://github.com/mjs/imapclient (imapclient/imapclient.py), 3-clause BSD license
-def _quote(arg):
+def quoted(arg):
+    """ Given a string, return a quoted string as per RFC 3501, section 9.
+
+        Implementation copied from https://github.com/mjs/imapclient
+        (imapclient/imapclient.py), 3-clause BSD license
+    """
     if isinstance(arg, str):
         arg = arg.replace('\\', '\\\\')
         arg = arg.replace('"', '\\"')
@@ -417,7 +421,7 @@ class IMAP4ClientProtocol(asyncio.Protocol):
     @asyncio.coroutine
     def login(self, user, password):
         response = yield from self.execute(
-            Command('LOGIN', self.new_tag(), user, '%s' % _quote(password), loop=self.loop))
+            Command('LOGIN', self.new_tag(), user, '%s' % quoted(password), loop=self.loop))
 
         if 'OK' == response.result:
             self.state = AUTH

--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -93,6 +93,19 @@ Commands = {
 Response = namedtuple('Response', 'result lines')
 
 
+# copied from https://github.com/mjs/imapclient (imapclient/imapclient.py), 3-clause BSD license
+def _quote(arg):
+    if isinstance(arg, str):
+        arg = arg.replace('\\', '\\\\')
+        arg = arg.replace('"', '\\"')
+        q = '"'
+    else:
+        arg = arg.replace(b'\\', b'\\\\')
+        arg = arg.replace(b'"', b'\\"')
+        q = b'"'
+    return q + arg + q
+
+
 class Command(object):
     def __init__(self, name, tag, *args, prefix=None, untagged_resp_name=None, loop=asyncio.get_event_loop(), timeout=None):
         self.name = name
@@ -404,7 +417,7 @@ class IMAP4ClientProtocol(asyncio.Protocol):
     @asyncio.coroutine
     def login(self, user, password):
         response = yield from self.execute(
-            Command('LOGIN', self.new_tag(), user, '"%s"' % password, loop=self.loop))
+            Command('LOGIN', self.new_tag(), user, '%s' % _quote(password), loop=self.loop))
 
         if 'OK' == response.result:
             self.state = AUTH

--- a/aioimaplib/tests/test_aioimaplib.py
+++ b/aioimaplib/tests/test_aioimaplib.py
@@ -370,6 +370,19 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
         self.assertTrue(imap_client.has_capability('UIDPLUS'))
 
     @asyncio.coroutine
+    def test_login_with_special_characters(self):
+        imap_client = aioimaplib.IMAP4(port=12345, loop=self.loop, timeout=3)
+        yield from asyncio.wait_for(imap_client.wait_hello_from_server(), 2)
+
+        result, data = yield from imap_client.login('user', 'pass"word')
+
+        self.assertEquals(aioimaplib.AUTH, imap_client.protocol.state)
+        self.assertEqual('OK', result)
+        self.assertEqual('LOGIN completed', data[-1])
+        self.assertTrue(imap_client.has_capability('IDLE'))
+        self.assertTrue(imap_client.has_capability('UIDPLUS'))
+
+    @asyncio.coroutine
     def test_login_twice(self):
         with self.assertRaises(aioimaplib.Error) as expected:
             imap_client = yield from self.login_user('user', 'pass')

--- a/aioimaplib/tests/test_utils.py
+++ b/aioimaplib/tests/test_utils.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#    aioimaplib : an IMAPrev4 lib using python asyncio
+#    Copyright (C) 2016  Bruno Thomas
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from unittest import TestCase
+from aioimaplib import quoted
+
+
+class TestQuote(TestCase):
+    def test_quote_encloses_string_in_dquote_character(self):
+        self.assertEqual('"hello"', quoted('hello'))
+
+    def test_quote_escapes_dquote_character(self):
+        self.assertEqual('"hello\\"world"', quoted('hello"world'))
+
+    def test_quote_escapes_backlash_character(self):
+        self.assertEqual('"hello\\\\world"', quoted('hello\\world'))
+
+    def test_quote_returns_str_when_input_is_str(self):
+        self.assertTrue(isinstance(quoted('hello'), str))
+
+    def test_quote_returns_bytes_when_input_is_bytes(self):
+        self.assertTrue(isinstance(quoted(b'hello'), bytes))


### PR DESCRIPTION
Hello,

I've build on @FelixShwarz's PR:

- Renamed '_quote' to 'quoted', which matches the corresponding name in the ABNF defined in RFC 3501 section 9 (https://tools.ietf.org/html/rfc3501#section-9)
- Added unit tests to cover the behaviour of the quoting function