### PR TITLE
Add unit tests for SSL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,7 +184,6 @@ To add an imaplib or imaplib2 command you can :
 Not unit tested
 ---------------
 - PREAUTH
-- SSL
 
 TODO
 ----

--- a/aioimaplib/tests/imapserver.py
+++ b/aioimaplib/tests/imapserver.py
@@ -662,13 +662,14 @@ class MockImapServer(object):
     def get_connection(self, user):
         return self._server_state.get_connection(user)
 
-    def run_server(self, host='localhost', port=1143, fetch_chunk_size=0):
+    def run_server(self, host='localhost', port=1143, fetch_chunk_size=0, ssl_context=None):
         def create_protocol():
             protocol = ImapProtocol(self._server_state, fetch_chunk_size, self.capabilities, self.loop)
             self._connections.append(protocol)
             return protocol
 
-        return self.loop.run_until_complete(self.loop.create_server(create_protocol, host, port))
+        server = self.loop.create_server(create_protocol, host, port, ssl=ssl_context)
+        return self.loop.run_until_complete(server)
 
     def reset(self):
         self._server_state.reset()

--- a/aioimaplib/tests/ssl_cert.py
+++ b/aioimaplib/tests/ssl_cert.py
@@ -1,0 +1,52 @@
+import os
+import tempfile
+
+from OpenSSL import crypto
+
+
+def create_temp_self_signed_cert():
+    """ Create a self signed SSL certificate in temporary files for host
+        'localhost'
+
+    Returns a tuple containing the certificate file name and the key
+    file name.
+
+    It is the caller's responsibility to delete the files after use
+    """
+    # create a key pair
+    key = crypto.PKey()
+    key.generate_key(crypto.TYPE_RSA, 1024)
+
+    # create a self-signed cert
+    cert = crypto.X509()
+    cert.get_subject().C = "UK"
+    cert.get_subject().ST = "London"
+    cert.get_subject().L = "London"
+    cert.get_subject().O = "aioimaplib"
+    cert.get_subject().OU = "aioimaplib"
+    cert.get_subject().CN = 'localhost'
+    cert.set_serial_number(1000)
+    cert.gmtime_adj_notBefore(0)
+    cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
+    cert.set_issuer(cert.get_subject())
+    cert.set_pubkey(key)
+    cert.sign(key, 'sha1')
+
+    # Save certificate in temporary file
+    (cert_file_fd, cert_file_name) = tempfile.mkstemp(suffix='.crt', prefix='cert')
+    cert_file = os.fdopen(cert_file_fd, 'wb')
+    cert_file.write(
+        crypto.dump_certificate(crypto.FILETYPE_PEM, cert)
+    )
+    cert_file.close()
+
+    # Save key in temporary file
+    (key_file_fd, key_file_name) = tempfile.mkstemp(suffix='.key', prefix='cert')
+    key_file = os.fdopen(key_file_fd, 'wb')
+    key_file.write(
+        crypto.dump_privatekey(crypto.FILETYPE_PEM, key)
+    )
+    key_file.close()
+
+    # Return file names
+    return (cert_file_name, key_file_name)

--- a/aioimaplib/tests/test_imapserver.py
+++ b/aioimaplib/tests/test_imapserver.py
@@ -145,13 +145,15 @@ class TestServerState(unittest.TestCase):
 
 
 class WithImapServer(object):
-    def _init_server(self, loop, capabilities=None):
+    def _init_server(self, loop, capabilities=None, ssl_context=None):
         self.loop = loop
         if capabilities is not None:
             self.imapserver = MockImapServer(loop=loop, capabilities=capabilities)
         else:
             self.imapserver = MockImapServer(loop=loop)
-        self.server = self.imapserver.run_server(host='localhost', port=12345, fetch_chunk_size=64)
+        self.server = self.imapserver.run_server(
+            host='localhost', port=12345, fetch_chunk_size=64, ssl_context=ssl_context
+        )
 
     @asyncio.coroutine
     def _shutdown_server(self):

--- a/aioimaplib/tests/test_ssl_cert.py
+++ b/aioimaplib/tests/test_ssl_cert.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#    aioimaplib : an IMAPrev4 lib using python asyncio
+#    Copyright (C) 2016  Bruno Thomas
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
+
+from OpenSSL import crypto
+from unittest import TestCase
+
+from aioimaplib.tests.ssl_cert import create_temp_self_signed_cert
+
+
+class TestCreateTempSelfSignedCert(TestCase):
+    def setUp(self):
+        self.cert, self.key = create_temp_self_signed_cert()
+
+    def tearDown(self):
+        os.remove(self.cert)
+        os.remove(self.key)
+
+    def test_create_temp_self_signed_cert_returns_two_file_names(self):
+        self.assertTrue(os.path.isfile(self.cert))
+        self.assertTrue(os.path.isfile(self.key))
+
+    def test_create_temp_self_signed_cert_returns_cert_as_first_value(self):
+        with open(self.cert, 'rb') as f:
+            data = f.read()
+
+        try:
+            crypto.load_certificate(crypto.FILETYPE_PEM, data)
+        except crypto.Error:
+            self.fail('First file is not a certificate')
+
+    def test_create_temp_self_signed_cert_returns_key_as_second_value(self):
+        with open(self.key, 'rb') as f:
+            data = f.read()
+
+        try:
+            crypto.load_privatekey(crypto.FILETYPE_PEM, data)
+        except crypto.Error:
+            self.fail('First file is not a key')
+
+    def test_create_temp_self_signed_cert_can_generate_more_than_one_pair_of_keys(self):
+        (second_cert, second_key) = create_temp_self_signed_cert()
+
+        # Check the second certificate is different and exists
+        self.assertNotEqual(self.cert, second_cert)
+        self.assertTrue(os.path.isfile(second_cert))
+
+        # Check the second key is different and exists
+        self.assertNotEqual(self.key, second_key)
+        self.assertTrue(os.path.isfile(second_key))
+
+        # Clean up
+        os.remove(second_cert)
+        os.remove(second_key)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ pytz
 tzlocal
 imaplib2
 docutils
+pyopenssl


### PR DESCRIPTION
This PR adds unit tests for the SSL implementation.

Testing this required the IMAP4_SSL implementation to accept an optional custom ssl context (so we could test with self signed certificates). This makes sense anyway as users of the library might want to use self signed certificates - or pass other custom ssl options.

It didn't make sense to have IMAP4_SSL accept a custom ssl context, but not IMAP4 - because doing so would have caused unnecessary duplication of code (and thus possible bugs later if someone changed one implementation and not the other).

Thus the difference between IMAP4 and IMAP4_SSL is that the former will use a plain connection if no ssl context is provided, while the latter will create a default ssl context if none is provided.

This makes sense architecturally too as it means users of IMAP4 can delegate the choice of using SSL or not to higher level code without having to test for it and use a different class. IMAP4_SSL becomes a convenience class for users who want to quickly write something using SSL, and who are happy with the default ssl context settings.