### PR TITLE
Change test_fetch so it doesn't rely on knowing the email's body length

### DIFF
--- a/aioimaplib/tests/test_aioimaplib.py
+++ b/aioimaplib/tests/test_aioimaplib.py
@@ -463,9 +463,13 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
         self.imapserver.receive(mail)
 
         result, data = yield from imap_client.fetch('1', '(RFC822)')
+        content = mail.as_bytes()
 
         self.assertEqual('OK', result)
-        self.assertEqual(['1 FETCH (RFC822 {360}', mail.as_bytes(), ')', 'FETCH completed.'], data)
+        self.assertEqual([
+            '1 FETCH (RFC822 {%s}' % len(content), content, ')',
+            'FETCH completed.'
+        ], data)
 
     @asyncio.coroutine
     def test_fetch_by_uid_without_body(self):


### PR DESCRIPTION
The test `TestAioimaplib.test_fetch` relies on the generated email body being 360 bytes. When I run the tests locally (x86_64, Ubuntu 16.04, Python 3.5) the generated body is 378 bytes.

I don't know where the extra bytes come from - but the generated email looks correct to me. Given that it's not the purpose of `test_fetch` to check how the email body is generated I've updated the test so it doesn't rely on knowing the body's length.