### PR TITLE
Fix tests on newer OSes and newer Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - pip install -r dev-requirements.txt
   - pip install coveralls

--- a/aioimaplib/tests/imapserver.py
+++ b/aioimaplib/tests/imapserver.py
@@ -178,7 +178,7 @@ def critical_section(next_state):
 
     def decorator(func):
         def wrapper(self, *args, **kwargs):
-            asyncio.async(execute_section(self, next_state, func, *args, **kwargs))
+            asyncio.ensure_future(execute_section(self, next_state, func, *args, **kwargs))
 
         return update_wrapper(wrapper, func)
 

--- a/aioimaplib/tests/ssl_cert.py
+++ b/aioimaplib/tests/ssl_cert.py
@@ -15,7 +15,7 @@ def create_temp_self_signed_cert():
     """
     # create a key pair
     key = crypto.PKey()
-    key.generate_key(crypto.TYPE_RSA, 1024)
+    key.generate_key(crypto.TYPE_RSA, 2048)
 
     # create a self-signed cert
     cert = crypto.X509()
@@ -25,6 +25,8 @@ def create_temp_self_signed_cert():
     cert.get_subject().O = "aioimaplib"
     cert.get_subject().OU = "aioimaplib"
     cert.get_subject().CN = '127.0.0.1'
+    ext = crypto.X509Extension(b'subjectAltName', False, b'IP:127.0.0.1')
+    cert.add_extensions([ext])
     cert.set_serial_number(1000)
     cert.gmtime_adj_notBefore(0)
     cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)

--- a/aioimaplib/tests/test_aioimaplib.py
+++ b/aioimaplib/tests/test_aioimaplib.py
@@ -882,10 +882,12 @@ class TestAioimaplibClocked(AioWithImapServer, asynctest.ClockedTestCase):
     @asyncio.coroutine
     def test_idle_start__exits_queueget_without_timeout_error(self):
         imap_client = yield from self.login_user('user', 'pass', select=True)
-        yield from imap_client.idle_start()
 
-        push_task = asyncio.ensure_future(imap_client.wait_server_push(TWENTY_NINE_MINUTES + 2))
-        yield from self.advance(TWENTY_NINE_MINUTES + 1)
+        idle_timeout = 5
+        yield from imap_client.idle_start(idle_timeout)
+
+        push_task = asyncio.ensure_future(imap_client.wait_server_push(idle_timeout + 2))
+        yield from self.advance(idle_timeout + 1)
 
         r = yield from asyncio.wait_for(push_task, 0)
         self.assertEqual(STOP_WAIT_SERVER_PUSH, r)

--- a/aioimaplib/tests/test_aioimaplib.py
+++ b/aioimaplib/tests/test_aioimaplib.py
@@ -594,8 +594,8 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
     def test_concurrency_1_executing_sync_commands_sequentially(self):
         imap_client = yield from self.login_user('user', 'pass')
 
-        f1 = asyncio.async(imap_client.examine('INBOX'))
-        f2 = asyncio.async(imap_client.examine('MAILBOX'))
+        f1 = asyncio.ensure_future(imap_client.examine('INBOX'))
+        f2 = asyncio.ensure_future(imap_client.examine('MAILBOX'))
 
         yield from asyncio.wait([f1, f2])
         self.assertIsNone(f1.exception())
@@ -606,8 +606,8 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
         self.imapserver.receive(Mail.create(['user']))
         imap_client = yield from self.login_user('user', 'pass', select=True)
 
-        f1 = asyncio.async(imap_client.fetch('1', '(RFC822)'))
-        f2 = asyncio.async(imap_client.fetch('1', '(RFC822)'))
+        f1 = asyncio.ensure_future(imap_client.fetch('1', '(RFC822)'))
+        f2 = asyncio.ensure_future(imap_client.fetch('1', '(RFC822)'))
 
         yield from asyncio.wait([f1, f2])
         self.assertIsNone(f1.exception())
@@ -619,9 +619,9 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
         self.imapserver.receive(Mail.create(['user']))
         imap_client = yield from self.login_user('user', 'pass', select=True)
 
-        store = asyncio.async(imap_client.store('1', '+FLAGS (FOO)'))
-        copy = asyncio.async(imap_client.copy('1', 'MBOX'))
-        expunge = asyncio.async(imap_client.expunge())
+        store = asyncio.ensure_future(imap_client.store('1', '+FLAGS (FOO)'))
+        copy = asyncio.ensure_future(imap_client.copy('1', 'MBOX'))
+        expunge = asyncio.ensure_future(imap_client.expunge())
 
         yield from asyncio.wait([store, copy, expunge])
         self.assertEquals(0, extract_exists((yield from imap_client.select())))
@@ -633,9 +633,9 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
         self.imapserver.receive(Mail.create(['user']))
         imap_client = yield from self.login_user('user', 'pass', select=True)
 
-        asyncio.async(imap_client.copy('1', 'MBOX'))
-        asyncio.async(imap_client.expunge())
-        examine = asyncio.async(imap_client.examine('MBOX'))
+        asyncio.ensure_future(imap_client.copy('1', 'MBOX'))
+        asyncio.ensure_future(imap_client.expunge())
+        examine = asyncio.ensure_future(imap_client.examine('MBOX'))
 
         self.assertEquals(1, extract_exists((yield from asyncio.wait_for(examine, 1))))
 
@@ -851,7 +851,7 @@ class TestAioimaplibClocked(AioWithImapServer, asynctest.ClockedTestCase):
         yield from (imap_client.protocol.execute(Command(
             'DELAY', imap_client.protocol.new_tag(), '3', loop=self.loop)))
 
-        noop_task = asyncio.async(imap_client.protocol.execute(
+        noop_task = asyncio.ensure_future(imap_client.protocol.execute(
             Command('NOOP', imap_client.protocol.new_tag(), '', loop=self.loop, timeout=2)))
         yield from self.advance(1)
         self.assertEqual(1, len(imap_client.protocol.pending_async_commands))
@@ -868,7 +868,7 @@ class TestAioimaplibClocked(AioWithImapServer, asynctest.ClockedTestCase):
         yield from (imap_client.protocol.execute(Command(
             'DELAY', imap_client.protocol.new_tag(), '3', loop=self.loop)))
 
-        delay_task = asyncio.async(imap_client.protocol.execute(
+        delay_task = asyncio.ensure_future(imap_client.protocol.execute(
             Command('DELAY', imap_client.protocol.new_tag(), '0', loop=self.loop, timeout=2)))
         yield from self.advance(1)
         self.assertIsNotNone(imap_client.protocol.pending_sync_command)
@@ -884,7 +884,7 @@ class TestAioimaplibClocked(AioWithImapServer, asynctest.ClockedTestCase):
         imap_client = yield from self.login_user('user', 'pass', select=True)
         yield from imap_client.idle_start()
 
-        push_task = asyncio.async(imap_client.wait_server_push(TWENTY_NINE_MINUTES + 2))
+        push_task = asyncio.ensure_future(imap_client.wait_server_push(TWENTY_NINE_MINUTES + 2))
         yield from self.advance(TWENTY_NINE_MINUTES + 1)
 
         r = yield from asyncio.wait_for(push_task, 0)

--- a/aioimaplib/tests/test_imapserver_aioimaplib.py
+++ b/aioimaplib/tests/test_imapserver_aioimaplib.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#    aioimaplib : an IMAPrev4 lib using python asyncio
+#    Copyright (C) 2016  Bruno Thomas
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import asyncio
+
+import asynctest
+
+from aioimaplib import extract_exists
+from aioimaplib.aioimaplib import Command
+from aioimaplib.tests.test_aioimaplib import AioWithImapServer
+
+
+class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
+    def setUp(self):
+        self._init_server(self.loop)
+
+    @asyncio.coroutine
+    def tearDown(self):
+        yield from self._shutdown_server()
+
+    @asyncio.coroutine
+    def test_append_too_long(self):
+        imap_client = yield from self.login_user('user@mail', 'pass')
+        self.assertEquals(0, extract_exists((yield from imap_client.examine('INBOX'))))
+
+        message_bytes = b'do you see me ?'
+        imap_client.protocol.literal_data = message_bytes * 2
+
+        args = ['INBOX', '{%s}' % len(message_bytes)]
+        response = yield from imap_client.protocol.execute(
+            Command('APPEND', imap_client.protocol.new_tag(), *args, loop=self.loop)
+        )
+        self.assertEquals('BAD', response.result)
+        self.assertTrue('expected CRLF but got' in response.lines[0])
+
+    @asyncio.coroutine
+    def test_append_too_short(self):
+        imap_client = yield from self.login_user('user@mail', 'pass')
+        self.assertEquals(0, extract_exists((yield from imap_client.examine('INBOX'))))
+
+        message_bytes = b'do you see me ?' * 2
+        imap_client.protocol.literal_data = message_bytes[:5]
+
+        args = ['INBOX', '{%s}' % len(message_bytes)]
+        response = yield from imap_client.protocol.execute(
+            Command('APPEND', imap_client.protocol.new_tag(), *args, loop=self.loop)
+        )
+        self.assertEquals('BAD', response.result)
+        self.assertTrue('expected 30 but was' in response.lines[0])


### PR DESCRIPTION
A smattering of test fixes
* Replace asyncio.async with asyncio.ensure_future so the tests don't raise SyntaxError on Python 3.7 and above
* Allow SSL/TLS tests to run successfully on newer distributions (e.g. Debian buster), where OpenSSL is more strict about the sort of certificate it wants.
* Address interaction between `test_idle_start__exits_queueget_without_timeout_error` and the server's every-10-seconds keepalive response by shortening the test to run before the keepalive period expires.  (Should fix #32, and seen in #35)
* Address asyncio behavior in newer Python versions that were causing imapserver to mis-parse IMAP literal data (the other failure in #35)

Fixes #32
Fixes #35