### PR TITLE
Fix compatibility with Python 3.10 loop removal

### DIFF
--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -150,7 +150,7 @@ class Command(object):
 
         self._exception = None
         self._loop = loop if loop is not None else get_running_loop()
-        self._event = asyncio.Event(loop=self._loop)
+        self._event = asyncio.Event()
         self._timeout = timeout
         self._timer = asyncio.Handle(lambda: None, None, self._loop)  # fake timer
         self._set_timer()
@@ -323,7 +323,7 @@ class IMAP4ClientProtocol(asyncio.Protocol):
         self.pending_async_commands = dict()
         self.pending_sync_command = None
         self.idle_queue = asyncio.Queue()
-        self._idle_event = asyncio.Event(loop=loop)
+        self._idle_event = asyncio.Event()
         self.imap_version = None
         self.literal_data = None
         self.incomplete_line = b''

--- a/aioimaplib/tests/test_aioimaplib.py
+++ b/aioimaplib/tests/test_aioimaplib.py
@@ -868,7 +868,7 @@ class TestAioimaplibClocked(AioWithImapServer, asynctest.ClockedTestCase):
         self.assertEqual(1, len(imap_client.protocol.pending_async_commands))
         await self.advance(1.1)
 
-        finished, pending = await asyncio.wait([noop_task], loop=self.loop)
+        finished, pending = await asyncio.wait([noop_task])
         self.assertTrue(noop_task in finished)
         self.assertTrue(isinstance(noop_task.exception(), CommandTimeout))
         self.assertEqual(0, len(imap_client.protocol.pending_async_commands))
@@ -884,7 +884,7 @@ class TestAioimaplibClocked(AioWithImapServer, asynctest.ClockedTestCase):
         self.assertIsNotNone(imap_client.protocol.pending_sync_command)
         await self.advance(1.1)
 
-        finished, pending = await asyncio.wait([delay_task], loop=self.loop)
+        finished, pending = await asyncio.wait([delay_task])
         self.assertTrue(delay_task in finished)
         self.assertTrue(isinstance(delay_task.exception(), CommandTimeout))
         self.assertIsNone(imap_client.protocol.pending_sync_command)

--- a/example/imap_fetch.py
+++ b/example/imap_fetch.py
@@ -1,5 +1,5 @@
 import re
-from asyncio import get_event_loop, wait_for
+from asyncio import run, wait_for
 from collections import namedtuple
 from email.message import Message
 from email.parser import BytesHeaderParser, BytesParser
@@ -77,4 +77,4 @@ async def imap_loop(host, user, password) -> None:
 
 
 if __name__ == '__main__':
-    get_event_loop().run_until_complete(imap_loop('imap.server', 'account_id', 'password'))
+    run(imap_loop('imap.server', 'account_id', 'password'))


### PR DESCRIPTION
Fixes https://github.com/bamthomas/aioimaplib/issues/75

Note: when running local tests on without any changes on Python 3.9 I had 3 failed tests, I am not sure if they are due differences in my environment.

When running tests on Python 3.10 after changes two additional tests failed due to loop argument removal and they are fixed in this PR.
