### PR TITLE
Imap Oauth for Outlook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ dist
 .coverage
 build
 .tox
+example/.oauth_token.json
+

--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,16 @@ Or loading config file (for example with logging.config.dictConfig(yaml.load(fil
         propagate: no
     ...
 
+Authentication with OAuth2
+--------------------------
+
+Starting with the 01/01/23 Microsoft Outlook can only be accessed with OAuth2. 
+You need to register you client to be used with oauth. Find more 
+:https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth:`here`.
+
+This might be also used with Google Mail, but it is not tested for it.
+
+
 Tested with
 -----------
 
@@ -200,7 +210,7 @@ TODO
 .. _rfc2342: https://tools.ietf.org/html/rfc2342
 .. _rfc4469: https://tools.ietf.org/html/rfc4469
 
-- 23/25 IMAP4rev1 commands are implemented from the main rfc3501_. 'STARTTLS' and 'AUTHENTICATE' are still missing.
+- 23/25 IMAP4rev1 commands are implemented from the main rfc3501_. 'STARTTLS' and 'AUTHENTICATE'(except with XOAUTH2) are still missing.
 - 'COMPRESS' from rfc4978_
 - 'SETACL' 'DELETEACL' 'GETACL' 'MYRIGHTS' 'LISTRIGHTS' from ACL rfc4314_
 - 'GETQUOTA': 'GETQUOTAROOT': 'SETQUOTA' from quota rfc2087_

--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -423,10 +423,8 @@ class IMAP4ClientProtocol(asyncio.Protocol):
                 await self.pending_async_commands[command.untagged_resp_name].wait()
             self.pending_async_commands[command.untagged_resp_name] = command
 
-        print("actually sending command")
         self.send(str(command))
         try:
-            print("waiting")
             await command.wait()
         except CommandTimeout:
             if Commands.get(command.name).exec == Exec.is_sync:

--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -15,6 +15,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import asyncio
+from base64 import b64encode
 import functools
 import logging
 import random
@@ -422,8 +423,10 @@ class IMAP4ClientProtocol(asyncio.Protocol):
                 await self.pending_async_commands[command.untagged_resp_name].wait()
             self.pending_async_commands[command.untagged_resp_name] = command
 
+        print("actually sending command")
         self.send(str(command))
         try:
+            print("waiting")
             await command.wait()
         except CommandTimeout:
             if Commands.get(command.name).exec == Exec.is_sync:
@@ -457,6 +460,25 @@ class IMAP4ClientProtocol(asyncio.Protocol):
             for line in response.lines:
                 if b'CAPABILITY' in line:
                     self.capabilities = self.capabilities.union(set(line.decode().replace('CAPABILITY', '').strip().split()))
+        return response
+
+    @change_state
+    async def xoauth2(self, user: str, token: str) -> Response:
+        """Authentication with XOAUTH2.
+
+        Tested with outlook.
+        
+        Specification:
+        https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth
+        https://developers.google.com/gmail/imap/xoauth2-protocol
+        """
+        sasl_string = b64encode(f"user={user}\1auth=Bearer {token}\1\1".encode("ascii"))
+
+        response = await self.execute(
+            Command('AUTHENTICATE', self.new_tag(), 'XOAUTH2', sasl_string.decode("ascii"), loop=self.loop))
+
+        if 'OK' == response.result:
+            self.state = AUTH
         return response
 
     @change_state
@@ -695,6 +717,9 @@ class IMAP4(object):
 
     async def login(self, user: str, password: str) -> Response:
         return await asyncio.wait_for(self.protocol.login(user, password), self.timeout)
+
+    async def xoauth2(self, user: str, token: bytes) -> Response:
+        return await asyncio.wait_for(self.protocol.xoauth2(user, token), self.timeout)
 
     async def logout(self) -> Response:
         return await asyncio.wait_for(self.protocol.logout(), self.timeout)

--- a/aioimaplib/tests/test_aioimaplib.py
+++ b/aioimaplib/tests/test_aioimaplib.py
@@ -407,6 +407,16 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
         self.assertTrue(imap_client.has_capability('IDLE'))
         self.assertTrue(imap_client.has_capability('UIDPLUS'))
 
+    async def test_xoauth2(self):
+        imap_client = aioimaplib.IMAP4(port=12345, loop=self.loop, timeout=3)
+        await asyncio.wait_for(imap_client.wait_hello_from_server(), 2)
+
+        result, data = await imap_client.xoauth2('user', 'myspecialtoken')
+
+        self.assertEquals(aioimaplib.AUTH, imap_client.protocol.state)
+        self.assertEqual('OK', result)
+        self.assertEqual(b'AUTHENTICATE completed', data[-1])
+
     async def test_login_with_special_characters(self):
         imap_client = aioimaplib.IMAP4(port=12345, loop=self.loop, timeout=3)
         await asyncio.wait_for(imap_client.wait_hello_from_server(), 2)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,4 +7,4 @@ imaplib2
 docutils
 pyopenssl
 twine
-httpx-xoauth
+httpx-oauth

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ imaplib2
 docutils
 pyopenssl
 twine
+httpx-xoauth

--- a/example/xoauth2.py
+++ b/example/xoauth2.py
@@ -1,0 +1,185 @@
+import asyncio
+import logging
+import socket
+import webbrowser
+from pathlib import Path
+from pprint import pprint
+from urllib.parse import parse_qs
+import json
+
+from httpx_oauth.oauth2 import OAuth2, OAuth2Token
+
+from aioimaplib import IMAP4_SSL
+
+CALLBACK_HTTP_PORT = 12345
+
+# for office365
+client = OAuth2(
+    "<your-client-id>",
+    "<your-client-secret>",
+    "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize",
+    "https://login.microsoftonline.com/organizations/oauth2/v2.0/token",
+)
+
+SCOPES = [
+    "offline_access",
+    "https://outlook.office.com/IMAP.AccessAsUser.All",
+]
+
+# for google
+# this is not tested yet.
+# from httpx_oauth.clients.google import GoogleOAuth2
+
+# client = GoogleOAuth2(
+#     "0f2c93d4-6a81-4597-8bf3-0002869d82fb",
+#     "rxN8Q~FABEmDxwiS7TtflBUPf~FkGR2raAtHlaQ6",
+# )
+# SCOPES = ["https://mail.google.com/"]
+
+
+logging.basicConfig(level=logging.DEBUG)
+
+token_path = Path(__file__).parent / ".oauth_token.json"
+
+
+async def main():
+
+    token = await get_token()
+
+    client = IMAP4_SSL("outlook.office365.com")
+
+    await client.wait_hello_from_server()
+    result = await client.xoauth2("<your-username>", token)
+    pprint(result.lines)
+
+    await client.select()
+    result = await client.uid_search("1:*", charset="us-ascii")
+
+    pprint(result.lines)
+
+    await client.close()
+
+
+# These are functions to aquire a token and persist it/refresh it
+# if you have issues you can delete the token .oauth_token.json to re-aquire it
+
+
+async def get_token():
+    if not token_path.is_file():
+        token = await authorization()
+    else:
+        with token_path.open() as f_in:
+            token_dict = json.load(f_in)
+        token = OAuth2Token(token_dict)
+
+    if token.is_expired():
+        token = client.refresh_token(token["refresh_token"])
+
+    # write token to file
+    with token_path.open("w") as f_out:
+        json.dump(token, f_out, indent=4)
+
+    return token["access_token"]
+
+
+async def start_server_and_open_browser(url):
+
+    response_queue = asyncio.Queue(1)
+
+    # start callback webserver
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("localhost", CALLBACK_HTTP_PORT))
+    server.listen()
+    # this is set so we can restart the server quickly without getting
+    # OSError: [Errno 48] Address already in use errors
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.setblocking(False)
+
+    server_task = asyncio.create_task(run_http_server(server, response_queue))
+
+    webbrowser.open(url)
+
+    val = await response_queue.get()
+    server.close()
+    server_task.cancel()
+
+    return val
+
+
+async def authorization():
+    """Authorizes"""
+
+    callback_url = f"http://localhost:{CALLBACK_HTTP_PORT}/"
+
+    url = await client.get_authorization_url(callback_url, scope=SCOPES)
+    token_respose = await start_server_and_open_browser(url)
+    access_token = await client.get_access_token(token_respose["code"][0], callback_url)
+
+    return access_token
+
+
+# this is a really small webserver to be able to receive the callback from oauth
+# heavlily inspired by https://github.com/jangia/http_server/blob/master/server.py
+
+CHUNK_LIMIT = 50
+DEFAULT_RESPONSE = "HTTP/1.1 {status} {status_msg}\r\nContent-Type: text/html; charset=UTF-8\r\nContent-Encoding: UTF-8\r\nAccept-Ranges: bytes\r\nConnection: closed\r\n\r\n{html}"
+
+
+def parse_request(request_str):
+    part_one, part_two = request_str.split("\r\n\r\n")
+    http_lines = part_one.split("\r\n")
+    method, url, _ = http_lines[0].split(" ")
+    if method != "GET":
+        status, status_msg = 405, "Not allowed"
+    else:
+        status, status_msg = 200, "OK"
+
+    return status, status_msg, url
+
+
+async def build_response(request, response_queue):
+    status, status_msg, url = parse_request(request)
+    html = ""
+    # if there is code in the response it is the one we want
+    if "code" in url:
+        query = parse_qs(url.split("?", 1)[1])
+        await response_queue.put(query)
+        html = "Thank you, auth is handed back to the cli."
+    else:
+        status = 404
+        status_msg = "Not Found"
+    response = DEFAULT_RESPONSE.format(
+        status=status, status_msg=status_msg, html=html
+    ).encode("utf-8")
+
+    return response
+
+
+async def read_request(client):
+    request = ""
+    while True:
+        chunk = (await asyncio.get_event_loop().sock_recv(client, CHUNK_LIMIT)).decode(
+            "utf8"
+        )
+        request += chunk
+        if len(chunk) < CHUNK_LIMIT:
+            break
+
+    return request
+
+
+async def handle_client(client, response_queue):
+    request = await read_request(client)
+    response = await build_response(request, response_queue)
+    await asyncio.get_event_loop().sock_sendall(client, response)
+    client.close()
+
+
+async def run_http_server(selected_server, response_queue):
+    while True:
+        client, _ = await asyncio.get_event_loop().sock_accept(selected_server)
+        asyncio.create_task(handle_client(client, response_queue))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/example/xoauth2.py
+++ b/example/xoauth2.py
@@ -26,13 +26,13 @@ SCOPES = [
     "https://outlook.office.com/IMAP.AccessAsUser.All",
 ]
 
-# for google
+# for google``
 # this is not tested yet.
 # from httpx_oauth.clients.google import GoogleOAuth2
 
 # client = GoogleOAuth2(
-#     "0f2c93d4-6a81-4597-8bf3-0002869d82fb",
-#     "rxN8Q~FABEmDxwiS7TtflBUPf~FkGR2raAtHlaQ6",
+# "<your-client-id>",
+# "<your-client-secret>",
 # )
 # SCOPES = ["https://mail.google.com/"]
 
@@ -45,7 +45,6 @@ token_path = Path(__file__).parent / ".oauth_token.json"
 async def main():
 
     token = await get_token()
-
     client = IMAP4_SSL("outlook.office365.com")
 
     await client.wait_hello_from_server()
@@ -112,8 +111,8 @@ async def authorization():
     callback_url = f"http://localhost:{CALLBACK_HTTP_PORT}/"
 
     url = await client.get_authorization_url(callback_url, scope=SCOPES)
-    token_respose = await start_server_and_open_browser(url)
-    access_token = await client.get_access_token(token_respose["code"][0], callback_url)
+    token_response = await start_server_and_open_browser(url)
+    access_token = await client.get_access_token(token_response["code"][0], callback_url)
 
     return access_token
 


### PR DESCRIPTION
Microsoft is disabling basic login with the start of 2023. This makes it necessary to use Authenticate with OAUTH2.

- This is in theory also compatible with Gmail, but I did not test it.
- I extended the server to support this.
- Wrote a unit test with a login.
- Tested with outlook365.
- Added a full example with acquire the token itself with the HTTP API.