### PR TITLE
Support for python 3.11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
+          - '3.11'
           - '3.10'
           - '3.9'
           - '3.8'

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ This library is inspired by imaplib_ and imaplib2_ from Piers Lauder, Nicolas Se
 
 The aim is to port the imaplib with asyncio_, to benefit from the sleep or treat model.
 
-It runs with python 3.7, 3.8, 3.9, 3.10.
+It runs with python 3.7, 3.8, 3.9, 3.10, 3.11.
 
 Example
 -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Communications :: Email :: Post-Office :: IMAP
     Topic :: Internet
 


### PR DESCRIPTION
This patch adds python 3.11to the tox and GHA targets.