### PR TITLE
Use assert instead of unittest assertions

### DIFF
--- a/aioimaplib/tests/test_acceptance_aioimaplib.py
+++ b/aioimaplib/tests/test_acceptance_aioimaplib.py
@@ -41,5 +41,5 @@ class TestAioimaplibAcceptance(AioWithImapServer, TestCase):
 
             result, data = await imap_client.fetch('1', '(RFC822)')
 
-            self.assertEqual('OK', result)
-            self.assertEqual([b'1 FETCH (RFC822 {418898}', mail.as_bytes(), b')', b'FETCH completed.'], data)
+            assert 'OK' == result
+            assert [b'1 FETCH (RFC822 {418898}', mail.as_bytes(), b')', b'FETCH completed.'] == data

--- a/aioimaplib/tests/test_imapserver_aioimaplib.py
+++ b/aioimaplib/tests/test_imapserver_aioimaplib.py
@@ -32,7 +32,7 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
 
     async def test_append_too_long(self):
         imap_client = await self.login_user('user@mail', 'pass')
-        self.assertEquals(0, extract_exists((await imap_client.examine('INBOX'))))
+        assert 0 == extract_exists((await imap_client.examine('INBOX')))
 
         message_bytes = b'do you see me ?'
         imap_client.protocol.literal_data = message_bytes * 2
@@ -41,12 +41,12 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
         response = await imap_client.protocol.execute(
             Command('APPEND', imap_client.protocol.new_tag(), *args, loop=self.loop)
         )
-        self.assertEquals('BAD', response.result)
-        self.assertTrue(b'expected CRLF but got' in response.lines[0])
+        assert 'BAD' == response.result
+        assert b'expected CRLF but got' in response.lines[0]
 
     async def test_append_too_short(self):
         imap_client = await self.login_user('user@mail', 'pass')
-        self.assertEquals(0, extract_exists((await imap_client.examine('INBOX'))))
+        assert 0 == extract_exists((await imap_client.examine('INBOX')))
 
         message_bytes = b'do you see me ?' * 2
         imap_client.protocol.literal_data = message_bytes[:5]
@@ -55,5 +55,5 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
         response = await imap_client.protocol.execute(
             Command('APPEND', imap_client.protocol.new_tag(), *args, loop=self.loop)
         )
-        self.assertEquals('BAD', response.result)
-        self.assertTrue(b'expected 30 but was' in response.lines[0])
+        assert 'BAD' == response.result
+        assert b'expected 30 but was' in response.lines[0]

--- a/aioimaplib/tests/test_imapserver_imaplib.py
+++ b/aioimaplib/tests/test_imapserver_imaplib.py
@@ -31,6 +31,7 @@ from aioimaplib.tests.imapserver import Mail
 from aioimaplib.tests.ssl_cert import create_temp_self_signed_cert
 from aioimaplib.tests.test_imapserver import WithImapServer
 from pytz import utc
+import pytest
 
 
 class TestImapServerWithImaplib(WithImapServer, TestCase):
@@ -49,7 +50,7 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         pending_imap = self.loop.run_in_executor(None, functools.partial(imaplib.IMAP4, host='127.0.0.1', port=12345))
         imap_client = await asyncio.wait_for(pending_imap, 1)
 
-        self.assertEqual('NONAUTH', imap_client.state)
+        assert 'NONAUTH' == imap_client.state
 
     async def test_server_login(self):
         pending_imap = self.loop.run_in_executor(None, functools.partial(imaplib.IMAP4, host='127.0.0.1', port=12345))
@@ -58,9 +59,9 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         pending_login = self.loop.run_in_executor(None, functools.partial(imap_client.login, 'user', 'pass'))
         result, data = await asyncio.wait_for(pending_login, 1)
 
-        self.assertEqual('OK', result)
-        self.assertEqual([b'LOGIN completed'], data)
-        self.assertEquals(imapserver.AUTH, self.imapserver.get_connection('user').state)
+        assert 'OK' == result
+        assert [b'LOGIN completed'] == data
+        assert imapserver.AUTH == self.imapserver.get_connection('user').state
 
     async def test_select_no_messages_in_mailbox(self):
         imap_client = await self.login_user('user@mail', 'pass')
@@ -68,9 +69,9 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.select)), 1)
 
-        self.assertEqual('OK', result)
-        self.assertEqual([b'0'], data)
-        self.assertEquals(imapserver.SELECTED, self.imapserver.get_connection('user@mail').state)
+        assert 'OK' == result
+        assert [b'0'] == data
+        assert imapserver.SELECTED == self.imapserver.get_connection('user@mail').state
 
     async def test_select_one_message_in_mailbox(self):
         self.imapserver.receive(Mail.create(to=['user'], mail_from='me', subject='hello'))
@@ -79,8 +80,8 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.select)), 1)
 
-        self.assertEqual('OK', result)
-        self.assertEqual([b'1'], data)
+        assert 'OK' == result
+        assert [b'1'] == data
 
     async def test_select_one_message_in_INBOX_zero_in_OTHER(self):
         self.imapserver.receive(Mail.create(to=['user'], mail_from='me', subject='hello'))
@@ -88,19 +89,19 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
 
         _, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.select)), 1)
-        self.assertEqual([b'1'], data)
+        assert [b'1'] == data
 
         _, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.select, 'OTHER')), 1)
-        self.assertEqual([b'0'], data)
+        assert [b'0'] == data
 
     async def test_examine_no_messages_in_mailbox(self):
         imap_client = await self.login_user('user', 'pass')
 
-        self.assertEquals(('OK', [b'0']), (await asyncio.wait_for(
-            self.loop.run_in_executor(None, functools.partial(imap_client.select, readonly=True)), 1)))
+        assert ('OK', [b'0']) == (await asyncio.wait_for(
+            self.loop.run_in_executor(None, functools.partial(imap_client.select, readonly=True)), 1))
 
-        self.assertEquals(imapserver.AUTH, self.imapserver.get_connection('user').state)
+        assert imapserver.AUTH == self.imapserver.get_connection('user').state
 
     async def test_search_by_uid_two_messages(self):
         self.imapserver.receive(Mail.create(['user']))
@@ -110,8 +111,8 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'search', 'utf-8', 'ALL')), 1)
 
-        self.assertEqual('OK', result)
-        self.assertEqual([b'1 2'], data)
+        assert 'OK' == result
+        assert [b'1 2'] == data
 
     async def test_search_by_uid_one_message_two_recipients(self):
         self.imapserver.receive(Mail.create(['user1', 'user2']))
@@ -120,16 +121,16 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'search', None, 'ALL')), 1)
 
-        self.assertEqual('OK', result)
-        self.assertEqual([b'1'], data)
+        assert 'OK' == result
+        assert [b'1'] == data
 
         imap_client = await self.login_user('user2', 'pass', select=True)
 
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'search', None, 'ALL')), 1)
 
-        self.assertEqual('OK', result)
-        self.assertEqual([b'1'], data)
+        assert 'OK' == result
+        assert [b'1'] == data
 
     async def test_fetch_one_message_by_uid(self):
         mail = Mail.create(['user'], mail_from='me', subject='hello', content='pleased to meet you, wont you guess my name ?')
@@ -139,23 +140,23 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'fetch', '1', '(RFC822)')), 1)
 
-        self.assertEqual('OK', result)
-        self.assertEqual([(b'1 (UID 1 RFC822 {360}', mail.as_bytes()), b')'], data)
+        assert 'OK' == result
+        assert [(b'1 (UID 1 RFC822 {360}', mail.as_bytes()), b')'] == data
 
     async def test_fetch_bad_range(self):
         imap_client = await self.login_user('user', 'pass', select=True)
 
-        with self.assertRaises(Exception) as expected:
+        with pytest.raises(Exception) as expected:
             await asyncio.wait_for(
                 self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'fetch', '0:*', '(RFC822)')), 1)
 
-        self.assertEqual('UID command error: BAD [b\'Error in IMAP command: Invalid uidset\']', str(expected.exception))
+            assert 'UID command error: BAD [b\'Error in IMAP command: Invalid uidset\']' == str(expected)
 
-        with self.assertRaises(Exception) as expected:
+        with pytest.raises(Exception) as expected:
             await asyncio.wait_for(
                 self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'fetch', '2:0', '(RFC822)')), 1)
 
-        self.assertEqual('UID command error: BAD [b\'Error in IMAP command: Invalid uidset\']', str(expected.exception))
+            assert 'UID command error: BAD [b\'Error in IMAP command: Invalid uidset\']' == str(expected)
 
     async def test_fetch_one_message_by_uid_with_bodypeek(self):
         mail = Mail.create(['user'], mail_from='me', subject='hello', content='this mail is still unread')
@@ -165,8 +166,8 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'fetch', '1', '(UID BODY.PEEK[])')), 1)
 
-        self.assertEqual('OK', result)
-        self.assertEqual([(b'1 (UID 1 BODY.PEEK[] {340}', mail.as_bytes()), b')'], data)
+        assert 'OK' == result
+        assert [(b'1 (UID 1 BODY.PEEK[] {340}', mail.as_bytes()), b')'] == data
 
     async def test_fetch_one_messages_by_uid_without_body(self):
         mail = Mail.create(['user'], mail_from='me', subject='hello', content='whatever')
@@ -176,8 +177,8 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'fetch', '1', '(UID FLAGS)')), 1)
 
-        self.assertEqual('OK', result)
-        self.assertEqual([(b'1 (UID 1 FLAGS ())')], data)
+        assert 'OK' == result
+        assert [(b'1 (UID 1 FLAGS ())')] == data
 
     async def test_fetch_one_messages_by_id_without_body(self):
         mail = Mail.create(['user'], mail_from='me', subject='hello', content='whatever')
@@ -186,11 +187,11 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
 
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.fetch, '1', '(UID FLAGS)')), 1)
-        self.assertEqual([(b'1 (UID 1 FLAGS ())')], data)
+        assert [(b'1 (UID 1 FLAGS ())')] == data
 
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.fetch, '1', '(FLAGS)')), 1)
-        self.assertEqual([(b'1 (FLAGS ())')], data)
+        assert [(b'1 (FLAGS ())')] == data
 
     async def test_fetch_messages_by_uid_range(self):
         mail = Mail.create(['user'], mail_from='me', subject='hello', content='whatever')
@@ -199,11 +200,11 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
 
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'fetch', '1:1', '(FLAGS)')), 1)
-        self.assertEqual([(b'1 (UID 1 FLAGS ())')], data)
+        assert [(b'1 (UID 1 FLAGS ())')] == data
 
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.fetch, '1:*', '(UID FLAGS)')), 1)
-        self.assertEqual([(b'1 (UID 1 FLAGS ())')], data)
+        assert [(b'1 (UID 1 FLAGS ())')] == data
 
     async def test_fetch_one_messages_by_uid_encoding_cp1252(self):
         self.imapserver.receive(Mail.create(['user'], mail_from='me', subject='hello', content='maître', encoding='cp1252'))
@@ -213,9 +214,9 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'fetch', '1', '(RFC822)')), 1)
 
         mail_content = data[0][1]
-        self.assertTrue(b'charset="cp1252"' in mail_content)
-        self.assertTrue(b'ma\xeetre' in mail_content)
-        self.assertEqual('maître', email.message_from_bytes(mail_content).get_payload().strip())
+        assert b'charset="cp1252"' in mail_content
+        assert b'ma\xeetre' in mail_content
+        assert 'maître' == email.message_from_bytes(mail_content).get_payload().strip()
 
     async def test_fetch_one_messages_out_of_two(self):
         self.imapserver.receive(Mail.create(['user'], mail_from='me', subject='hello', content='maître'))
@@ -225,7 +226,7 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         _, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'fetch', '1', '(RFC822)')), 1)
 
-        self.assertEqual(2, len(data))
+        assert 2 == len(data)
 
     async def test_fetch_one_message_with_headers(self):
         self.imapserver.receive(Mail.create(['user'], mail_from='me', subject='hello', content='maître'))
@@ -234,8 +235,8 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         _, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'fetch', '1', '(BODY.PEEK[HEADER.FIELDS (Content-type From)])')), 1)
 
-        self.assertEqual(b'1 (UID 1 BODY[HEADER.FIELDS (Content-type From)] {57}', data[0][0])
-        self.assertEqual(b'Content-type: text/plain; charset="utf-8"\r\nFrom: <me>\r\n\r\n', data[0][1])
+        assert b'1 (UID 1 BODY[HEADER.FIELDS (Content-type From)] {57}' == data[0][0]
+        assert b'Content-type: text/plain; charset="utf-8"\r\nFrom: <me>\r\n\r\n' == data[0][1]
 
     async def test_store(self):
         self.imapserver.receive(Mail.create(['user']))
@@ -243,13 +244,13 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
 
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'store', '1', '+FLAGS.SILENT (\Seen \Answered)')), 1)
-        self.assertEqual('OK', result)
+        assert 'OK' == result
 
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'fetch', '1', 'UID (FLAGS)')), 1)
 
-        self.assertEqual('OK', result)
-        self.assertEqual([b'1 (UID 1 FLAGS (\Seen \Answered))'], data)
+        assert 'OK' == result
+        assert [b'1 (UID 1 FLAGS (\Seen \Answered))'] == data
 
     async def test_store_and_search_by_keyword(self):
         self.imapserver.receive(Mail.create(['user']))
@@ -259,22 +260,22 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'search', None, 'KEYWORD FOO')), 1)
 
-        self.assertEqual('OK', result)
-        self.assertEqual([b''], data)
+        assert 'OK' == result
+        assert [b''] == data
 
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'store', '1', '+FLAGS (FOO)')), 1)
-        self.assertEqual('OK', result)
+        assert 'OK' == result
 
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'search', None, 'KEYWORD FOO')), 1)
-        self.assertEqual('OK', result)
-        self.assertEqual([b'1'], data)
+        assert 'OK' == result
+        assert [b'1'] == data
 
         result, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'search', None, 'UNKEYWORD FOO')), 1)
-        self.assertEqual('OK', result)
-        self.assertEqual([b'2'], data)
+        assert 'OK' == result
+        assert [b'2'] == data
 
     async def test_search_by_uid_range(self):
         self.imapserver.receive(Mail.create(['user']))
@@ -283,15 +284,15 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
 
         _, data = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'search', None, '1:2')), 1)
-        self.assertEqual([b'1 2'], data)
+        assert [b'1 2'] == data
 
         _, data = await asyncio.wait_for(
                     self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'search', None, '1:*')), 1)
-        self.assertEqual([b'1 2'], data)
+        assert [b'1 2'] == data
 
         _, data = await asyncio.wait_for(
                     self.loop.run_in_executor(None, functools.partial(imap_client.uid, 'search', None, '1:1')), 1)
-        self.assertEqual([b'1'], data)
+        assert [b'1'] == data
 
     async def test_expunge_messages(self):
         self.imapserver.receive(Mail.create(['user']))
@@ -300,60 +301,60 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
 
         await asyncio.wait_for(self.loop.run_in_executor(None, imap_client.expunge), 1)
 
-        self.assertEquals(('OK', [b'0']), (await asyncio.wait_for(
-            self.loop.run_in_executor(None, functools.partial(imap_client.select)), 1)))
+        assert ('OK', [b'0']) == (await asyncio.wait_for(
+            self.loop.run_in_executor(None, functools.partial(imap_client.select)), 1))
 
     async def test_noop(self):
         imap_client = await self.login_user('user', 'pass', select=True)
 
-        self.assertEquals(('OK', [b'NOOP completed.']),
-                          (await asyncio.wait_for(self.loop.run_in_executor(None, imap_client.noop), 1)))
+        assert ('OK', [b'NOOP completed.']) == \
+                          (await asyncio.wait_for(self.loop.run_in_executor(None, imap_client.noop), 1))
 
     async def test_check(self):
         imap_client = await self.login_user('user', 'pass', select=True)
 
-        self.assertEquals(('OK', [b'CHECK completed.']),
-                          (await asyncio.wait_for(self.loop.run_in_executor(None, imap_client.check), 1)))
+        assert ('OK', [b'CHECK completed.']) == \
+                          (await asyncio.wait_for(self.loop.run_in_executor(None, imap_client.check), 1))
 
     async def test_status(self):
         imap_client = await self.login_user('user', 'pass')
 
-        self.assertEquals(('OK', [b'INBOX (MESSAGES 0 UIDNEXT 1)']),
+        assert ('OK', [b'INBOX (MESSAGES 0 UIDNEXT 1)']) == \
                           (await asyncio.wait_for(
                               self.loop.run_in_executor(None, functools.partial(imap_client.status, 'INBOX',
-                                                                                '(MESSAGES UIDNEXT)')), 1)))
+                                                                                '(MESSAGES UIDNEXT)')), 1))
 
     async def test_subscribe_unsubscribe_lsub(self):
         imap_client = await self.login_user('user', 'pass')
 
-        self.assertEquals(('OK', [b'SUBSCRIBE completed.']),
+        assert ('OK', [b'SUBSCRIBE completed.']) == \
                           (await asyncio.wait_for(
                               self.loop.run_in_executor(None, functools.partial(
-                                  imap_client.subscribe, '#fr.soc.feminisme')), 1)))
+                                  imap_client.subscribe, '#fr.soc.feminisme')), 1))
 
-        self.assertEquals(('OK', [b'() "." #fr.soc.feminisme']),
+        assert ('OK', [b'() "." #fr.soc.feminisme']) == \
                           (await asyncio.wait_for(
                               self.loop.run_in_executor(None, functools.partial(
-                                  imap_client.lsub, '#fr', 'soc.*')), 1)))
+                                  imap_client.lsub, '#fr', 'soc.*')), 1))
 
-        self.assertEquals(('OK', [b'UNSUBSCRIBE completed.']),
+        assert ('OK', [b'UNSUBSCRIBE completed.']) == \
                           (await asyncio.wait_for(
                               self.loop.run_in_executor(None, functools.partial(
-                                  imap_client.unsubscribe, '#fr.soc.feminisme')), 1)))
+                                  imap_client.unsubscribe, '#fr.soc.feminisme')), 1))
 
-        self.assertEquals(('OK', [None]),
+        assert ('OK', [None]) == \
                           (await asyncio.wait_for(
                               self.loop.run_in_executor(None, functools.partial(
-                                  imap_client.lsub, '#fr', '.*')), 1)))
+                                  imap_client.lsub, '#fr', '.*')), 1))
 
     async def test_close(self):
         imap_client = await self.login_user('user', 'pass', select=True)
-        self.assertEquals(imapserver.SELECTED, self.imapserver.get_connection('user').state)
+        assert imapserver.SELECTED == self.imapserver.get_connection('user').state
 
-        self.assertEquals(('OK', [b'CLOSE completed.']),
-                          (await asyncio.wait_for(self.loop.run_in_executor(None, imap_client.close), 1)))
+        assert ('OK', [b'CLOSE completed.']) == \
+                          (await asyncio.wait_for(self.loop.run_in_executor(None, imap_client.close), 1))
 
-        self.assertEquals(imapserver.AUTH, self.imapserver.get_connection('user').state)
+        assert imapserver.AUTH == self.imapserver.get_connection('user').state
 
     async def test_copy_messages(self):
         self.imapserver.receive(Mail.create(['user']))
@@ -362,78 +363,78 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
 
         result, _ = await asyncio.wait_for(
             self.loop.run_in_executor(None, functools.partial(imap_client.copy, '1 2', 'MAILBOX')), 20)
-        self.assertEqual('OK', result)
+        assert 'OK' == result
 
-        self.assertEquals(('OK', [b'2']), (await asyncio.wait_for(
-            self.loop.run_in_executor(None, functools.partial(imap_client.select, 'MAILBOX')), 20)))
+        assert ('OK', [b'2']) == (await asyncio.wait_for(
+            self.loop.run_in_executor(None, functools.partial(imap_client.select, 'MAILBOX')), 20))
 
     async def test_create_delete_mailbox(self):
         imap_client = await self.login_user('user', 'pass')
 
-        self.assertEquals(('NO', [b'STATUS completed.']),
+        assert ('NO', [b'STATUS completed.']) == \
                           (await asyncio.wait_for(
-                              self.loop.run_in_executor(None, functools.partial(imap_client.status, 'MBOX', '(MESSAGES)')), 1)))
+                              self.loop.run_in_executor(None, functools.partial(imap_client.status, 'MBOX', '(MESSAGES)')), 1))
 
-        self.assertEquals(('OK', [b'CREATE completed.']),
+        assert ('OK', [b'CREATE completed.']) == \
                           (await asyncio.wait_for(
-                              self.loop.run_in_executor(None, functools.partial(imap_client.create, 'MBOX')), 1)))
+                              self.loop.run_in_executor(None, functools.partial(imap_client.create, 'MBOX')), 1))
 
-        self.assertEquals(('OK', [b'MBOX (MESSAGES 0)']),
+        assert ('OK', [b'MBOX (MESSAGES 0)']) == \
                           (await asyncio.wait_for(
-                              self.loop.run_in_executor(None, functools.partial(imap_client.status, 'MBOX', '(MESSAGES)')), 1)))
+                              self.loop.run_in_executor(None, functools.partial(imap_client.status, 'MBOX', '(MESSAGES)')), 1))
 
-        self.assertEquals(('OK', [b'DELETE completed.']),
+        assert ('OK', [b'DELETE completed.']) == \
                           (await asyncio.wait_for(
-                              self.loop.run_in_executor(None, functools.partial(imap_client.delete, 'MBOX')), 1)))
+                              self.loop.run_in_executor(None, functools.partial(imap_client.delete, 'MBOX')), 1))
 
-        self.assertEquals(('NO', [b'STATUS completed.']),
+        assert ('NO', [b'STATUS completed.']) == \
                           (await asyncio.wait_for(
-                              self.loop.run_in_executor(None, functools.partial(imap_client.status, 'MBOX', '(MESSAGES)')), 1)))
+                              self.loop.run_in_executor(None, functools.partial(imap_client.status, 'MBOX', '(MESSAGES)')), 1))
 
     async def test_rename_mailbox(self):
         self.imapserver.receive(Mail.create(['user']))
         imap_client = await self.login_user('user', 'pass')
 
-        self.assertEquals(('NO', [b'STATUS completed.']),
+        assert ('NO', [b'STATUS completed.']) == \
                           (await asyncio.wait_for(
-                              self.loop.run_in_executor(None, functools.partial(imap_client.status, 'MBOX', '(MESSAGES)')), 1)))
+                              self.loop.run_in_executor(None, functools.partial(imap_client.status, 'MBOX', '(MESSAGES)')), 1))
 
-        self.assertEquals(('OK', [b'RENAME completed.']),
+        assert ('OK', [b'RENAME completed.']) == \
                           (await asyncio.wait_for(
-                              self.loop.run_in_executor(None, functools.partial(imap_client.rename, 'INBOX', 'MBOX')), 1)))
+                              self.loop.run_in_executor(None, functools.partial(imap_client.rename, 'INBOX', 'MBOX')), 1))
 
-        self.assertEquals(('OK', [b'MBOX (MESSAGES 1)']),
+        assert ('OK', [b'MBOX (MESSAGES 1)']) == \
                           (await asyncio.wait_for(
-                              self.loop.run_in_executor(None, functools.partial(imap_client.status, 'MBOX', '(MESSAGES)')), 1)))
+                              self.loop.run_in_executor(None, functools.partial(imap_client.status, 'MBOX', '(MESSAGES)')), 1))
 
     async def test_list(self):
         imap_client = await self.login_user('user', 'pass')
-        self.assertEquals(('OK', [b'() "/" Drafts', b'() "/" INBOX', b'() "/" Sent', b'() "/" Trash']),
+        assert ('OK', [b'() "/" Drafts', b'() "/" INBOX', b'() "/" Sent', b'() "/" Trash']) == \
                           (await asyncio.wait_for(
-                              self.loop.run_in_executor(None, functools.partial(imap_client.list, '""', '*')), 1)))
+                              self.loop.run_in_executor(None, functools.partial(imap_client.list, '""', '*')), 1))
 
     async def test_append(self):
         imap_client = await self.login_user('user@mail', 'pass')
 
-        self.assertEquals(('OK', [b'0']), (await asyncio.wait_for(
-            self.loop.run_in_executor(None, functools.partial(imap_client.select, 'INBOX', readonly=True)), 2)))
+        assert ('OK', [b'0']) == (await asyncio.wait_for(
+            self.loop.run_in_executor(None, functools.partial(imap_client.select, 'INBOX', readonly=True)), 2))
 
         msg = Mail.create(['user@mail'], subject='append msg', content='do you see me ?')
-        self.assertEquals('OK', (await asyncio.wait_for(
+        assert 'OK' == (await asyncio.wait_for(
                               self.loop.run_in_executor(None, functools.partial(
-                                  imap_client.append, 'INBOX', 'FOO BAR', datetime.now(tz=utc), msg.as_bytes())), 2))[0])
+                                  imap_client.append, 'INBOX', 'FOO BAR', datetime.now(tz=utc), msg.as_bytes())), 2))[0]
 
-        self.assertEquals(('OK', [b'1']), (await asyncio.wait_for(
-            self.loop.run_in_executor(None, functools.partial(imap_client.select, 'INBOX', readonly=True)), 2)))
+        assert ('OK', [b'1']) == (await asyncio.wait_for(
+            self.loop.run_in_executor(None, functools.partial(imap_client.select, 'INBOX', readonly=True)), 2))
 
     async def test_logout(self):
         imap_client = await self.login_user('user', 'pass')
 
         result, data = await asyncio.wait_for(self.loop.run_in_executor(None, imap_client.logout), 1)
 
-        self.assertEqual('BYE', result)  # uhh ?
-        self.assertEqual([b'Logging out'], data)
-        self.assertEquals(imapserver.LOGOUT, self.imapserver.get_connection('user').state)
+        assert 'BYE' == result  # uhh ?
+        assert [b'Logging out'] == data
+        assert imapserver.LOGOUT == self.imapserver.get_connection('user').state
 
     async def test_rfc5032_within(self):
         self.imapserver.receive(Mail.create(['user'], date=datetime.now(tz=utc) - timedelta(seconds=84600 * 3))) # 1
@@ -441,19 +442,19 @@ class TestImapServerWithImaplib(WithImapServer, TestCase):
         self.imapserver.receive(Mail.create(['user'])) # 3
         imap_client = await self.login_user('user', 'pass', select=True)
 
-        self.assertEquals([b'2 3'], (await asyncio.wait_for(
-            self.loop.run_in_executor(None, functools.partial(imap_client.search, 'utf-8', 'YOUNGER', '84700')), 1))[1])
+        assert [b'2 3'] == (await asyncio.wait_for(
+            self.loop.run_in_executor(None, functools.partial(imap_client.search, 'utf-8', 'YOUNGER', '84700')), 1))[1]
 
-        self.assertEquals([b'1'], (await asyncio.wait_for(
-            self.loop.run_in_executor(None, functools.partial(imap_client.search, 'utf-8', 'OLDER', '84700')), 1))[1])
+        assert [b'1'] == (await asyncio.wait_for(
+            self.loop.run_in_executor(None, functools.partial(imap_client.search, 'utf-8', 'OLDER', '84700')), 1))[1]
 
     async def test_getquotaroot(self):
         imap_client = await self.login_user('user', 'pass')
         self.imapserver.receive(Mail.create(['user']))
 
-        self.assertEquals(('OK', [[b'INBOX INBOX'], [b'INBOX (STORAGE 292 5000)']]),
+        assert ('OK', [[b'INBOX INBOX'], [b'INBOX (STORAGE 292 5000)']]) == \
                           (await asyncio.wait_for(self.loop.run_in_executor(None,
-                                                        functools.partial(imap_client.getquotaroot, 'INBOX')), 1)))
+                                                        functools.partial(imap_client.getquotaroot, 'INBOX')), 1))
 
 
 class TestSSLImapServerWithImaplib(WithImapServer, TestCase):
@@ -492,4 +493,4 @@ class TestSSLImapServerWithImaplib(WithImapServer, TestCase):
         )
         imap_client = await asyncio.wait_for(pending_imap, 1)
 
-        self.assertEqual('NONAUTH', imap_client.state)
+        assert 'NONAUTH' == imap_client.state

--- a/aioimaplib/tests/test_imapserver_imaplib2.py
+++ b/aioimaplib/tests/test_imapserver_imaplib2.py
@@ -25,6 +25,7 @@ from mock import Mock
 from aioimaplib.tests import imapserver
 from aioimaplib.tests.imapserver import Mail
 from aioimaplib.tests.test_imapserver import WithImapServer
+import pytest
 
 
 class TestImapServerIdle(WithImapServer, TestCase):
@@ -48,10 +49,10 @@ class TestImapServerIdle(WithImapServer, TestCase):
         idle_callback.assert_called_once()
 
     async def test_login_twice(self):
-        with self.assertRaises(imaplib2.IMAP4.error) as expected:
+        with pytest.raises(imaplib2.IMAP4.error) as expected:
             imap_client = await self.login_user('user', 'pass', lib=imaplib2.IMAP4)
 
             await asyncio.wait_for(
                 self.loop.run_in_executor(None, functools.partial(imap_client.login, 'user', 'pass')), 1)
 
-        self.assertEqual(expected.exception.args, ('command LOGIN illegal in state AUTH',))
+            assert expected == 'command LOGIN illegal in state AUTH'

--- a/aioimaplib/tests/test_ssl_cert.py
+++ b/aioimaplib/tests/test_ssl_cert.py
@@ -20,49 +20,40 @@ from OpenSSL import crypto
 from unittest import TestCase
 
 from aioimaplib.tests.ssl_cert import create_temp_self_signed_cert
-
-
-class TestCreateTempSelfSignedCert(TestCase):
-    def setUp(self):
-        self.cert, self.key = create_temp_self_signed_cert()
+def setUp(self):
+    self.cert, self.key = create_temp_self_signed_cert()
 
     def tearDown(self):
         os.remove(self.cert)
         os.remove(self.key)
 
     def test_create_temp_self_signed_cert_returns_two_file_names(self):
-        self.assertTrue(os.path.isfile(self.cert))
-        self.assertTrue(os.path.isfile(self.key))
+        assert os.path.isfile(self.cert)
+        assert os.path.isfile(self.key)
 
     def test_create_temp_self_signed_cert_returns_cert_as_first_value(self):
         with open(self.cert, 'rb') as f:
             data = f.read()
 
-        try:
-            crypto.load_certificate(crypto.FILETYPE_PEM, data)
-        except crypto.Error:
-            self.fail('First file is not a certificate')
+            try:
+                crypto.load_certificate(crypto.FILETYPE_PEM, data)
+            except crypto.Error:
+                self.fail('First file is not a certificate')
 
     def test_create_temp_self_signed_cert_returns_key_as_second_value(self):
         with open(self.key, 'rb') as f:
             data = f.read()
 
-        try:
-            crypto.load_privatekey(crypto.FILETYPE_PEM, data)
-        except crypto.Error:
-            self.fail('First file is not a key')
+            try:
+                crypto.load_privatekey(crypto.FILETYPE_PEM, data)
+            except crypto.Error:
+                self.fail('First file is not a key')
 
     def test_create_temp_self_signed_cert_can_generate_more_than_one_pair_of_keys(self):
         (second_cert, second_key) = create_temp_self_signed_cert()
-
-        # Check the second certificate is different and exists
-        self.assertNotEqual(self.cert, second_cert)
-        self.assertTrue(os.path.isfile(second_cert))
-
-        # Check the second key is different and exists
-        self.assertNotEqual(self.key, second_key)
-        self.assertTrue(os.path.isfile(second_key))
-
-        # Clean up
+        assert self.cert != second_cert
+        assert os.path.isfile(second_cert)
+        assert self.key != second_key
+        assert os.path.isfile(second_key)
         os.remove(second_cert)
         os.remove(second_key)

--- a/aioimaplib/tests/test_utils.py
+++ b/aioimaplib/tests/test_utils.py
@@ -14,42 +14,43 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import pytest
 from unittest import TestCase
 from aioimaplib import quoted, arguments_rfs2971, ID_MAX_FIELD_LEN, ID_MAX_VALUE_LEN
 
 
 class TestQuote(TestCase):
     def test_quote_encloses_string_in_dquote_character(self):
-        self.assertEqual('"hello"', quoted('hello'))
+       assert '"hello"' == quoted('hello')
 
     def test_quote_escapes_dquote_character(self):
-        self.assertEqual('"hello\\"world"', quoted('hello"world'))
+       assert '"hello\\"world"' == quoted('hello"world')
 
     def test_quote_escapes_backlash_character(self):
-        self.assertEqual('"hello\\\\world"', quoted('hello\\world'))
+       assert '"hello\\\\world"' == quoted('hello\\world')
 
     def test_quote_returns_str_when_input_is_str(self):
-        self.assertTrue(isinstance(quoted('hello'), str))
+        assert isinstance(quoted('hello'), str)
 
 
 class TestArgument(TestCase):
     def test_arguments_rfs2971_empty(self):
-        self.assertEqual(['NIL'], arguments_rfs2971())
+       assert ['NIL'] == arguments_rfs2971()
 
     def test_arguments_rfs2971_with_kwargs(self):
-        self.assertEqual(['(', '"name"', '"test"', ')'], arguments_rfs2971(name='test'))
+       assert ['(', '"name"', '"test"', ')'] == arguments_rfs2971(name='test')
 
     def test_arguments_rfs2971_with_max_items(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             fields = range(31)
             arguments_rfs2971(**{str(field): field for field in fields})
 
     def test_arguments_rfs2971_with_max_field_length(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             field = 'test' * (ID_MAX_FIELD_LEN + 1)
             arguments_rfs2971(**{field: 'test'})
 
     def test_arguments_rfs2971_with_max_value_length(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             value = 'test' * (ID_MAX_VALUE_LEN + 1)
             arguments_rfs2971(field=value)


### PR DESCRIPTION
This uses the python `assert` statement instead of the unittest `self.assert*` methods for better readability.

This is [how it is recommended](https://docs.pytest.org/en/7.1.x/how-to/assert.html) to write assertions in pytest.