### PR TITLE
Make sure Futures are cleaned up correctly

### DIFF
--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -709,6 +709,7 @@ class IMAP4(object):
         self.host = host
         self.protocol = None
         self._idle_waiter = None
+        self.tasks: set[Future] = set()
         self.create_client(host, port, loop, conn_lost_cb, ssl_context)
 
     def create_client(self, host: str, port: int, loop: asyncio.AbstractEventLoop,


### PR DESCRIPTION
As maintainer of the `imap` integration in Home Assistant we noticed users see Errors in their logs like:
`Error doing job: Task was destroyed but it is pending`
This is caused when a future of  task is not held in memory and Garbage collection cancels the job. at a few places in the code `asyncio.ensure_future()` is used without storing a reference to the Future. When executions takes longer it can be garbage collected before it is done or canceled causing the error.

So calling `asyncio.ensure_future` starts a background task, but because this task is not stored, linked or referenced, the garbage collection might pick up the task and cancell it. According to https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task we need to make sure we remove or discard the task when it is done.

See also logs linked with:
https://github.com/home-assistant/core/issues/95239