### PR TITLE
Made `Command` class `__repr__` method more robust

### DIFF
--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -156,7 +156,7 @@ class Command(object):
         self._timer = asyncio.Handle(lambda: None, None, self._loop)  # fake timer
         self._set_timer()
         self._expected_size = 0
-        
+
         self._resp_literal_data = bytearray()
         self._resp_result = 'Init'
         self._resp_lines: List[bytes] = list()
@@ -164,7 +164,8 @@ class Command(object):
     def __repr__(self) -> str:
         return '{tag} {prefix}{name}{space}{args}'.format(
             tag=self.tag, prefix=self.prefix or '', name=self.name,
-            space=' ' if self.args else '', args=' '.join(self.args))
+            space=' ' if self.args else '', args=' '.join(str(arg) if arg is not None else '' \
+                                                          for arg in self.args))
 
     # for tests
     def __eq__(self, other):
@@ -473,7 +474,7 @@ class IMAP4ClientProtocol(asyncio.Protocol):
         """Authentication with XOAUTH2.
 
         Tested with outlook.
-        
+
         Specification:
         https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth
         https://developers.google.com/gmail/imap/xoauth2-protocol
@@ -787,7 +788,7 @@ class IMAP4(object):
         if not self.has_pending_idle():
             wait_for_ack.cancel()
             raise Abort('server returned error to IDLE command')
-        
+
         def start_stop_wait_server_push():
             task = asyncio.ensure_future(self.stop_wait_server_push())
             self.tasks.add(task)

--- a/aioimaplib/tests/test_aioimaplib.py
+++ b/aioimaplib/tests/test_aioimaplib.py
@@ -471,6 +471,18 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
         assert 'OK' == result
         assert b'1 2' == data[0]
 
+    async def test_search_messages(self):
+        """Increase compatibility with https://docs.python.org/3/library/imaplib.html#imap4-example."""
+        self.imapserver.receive(Mail.create(['user']))
+        self.imapserver.receive(Mail.create(['user']))
+        imap_client = await self.login_user('user', 'pass', select=True)
+
+        # E.g. typ, data = M.search(None, 'ALL')
+        result, data = await imap_client.search(None, 'ALL')
+
+        assert 'OK' == result
+        assert b'1 2' == data[0]
+
     async def test_uid_with_illegal_command(self):
         imap_client = await self.login_user('user', 'pass', select=True)
 


### PR DESCRIPTION
I started some work based on one of [imaplib's examples](https://docs.python.org/3/library/imaplib.html#module-imaplib).

## IMAP4 Example

```python
import getpass, imaplib

M = imaplib.IMAP4()
M.login(getpass.getuser(), getpass.getpass())
M.select()
typ, data = M.search(None, 'ALL')  # ← This is more supported now
for num in data[0].split():
    typ, data = M.fetch(num, '(RFC822)')
    print('Message %s\n%s\n' % (num, data[0][1]))
M.close()
M.logout()
```

I noticed that passing `None` as the first parameter got me an exception. To improve the robustness of the code, I added a generator expression that converts any `NoneType`s to empty strings.