### PR TITLE
Replaces unnessary async methods with coroutine generating methods

### DIFF
--- a/aioimaplib/tests/test_aioimaplib.py
+++ b/aioimaplib/tests/test_aioimaplib.py
@@ -753,7 +753,7 @@ class TestAioimaplib(AioWithImapServer, asynctest.TestCase):
 
         response = await imap_client.getquotaroot('INBOX')
 
-        assert response.lines == [b'INBOX (STORAGE 294 5000)', b'GETQUOTAROOT completed.']
+        assert response.lines == [b'INBOX (STORAGE 292 5000)', b'GETQUOTAROOT completed.']
 
     async def test_append(self):
         imap_client = await self.login_user('user@mail', 'pass')


### PR DESCRIPTION
### Methods have been stripped of _async_ and now return _Coroutine[Any, Any, Response]_ why?
- The async methods did not do anything requiring scheduling.
- Running them synchronously and returning the actually async parts as Coroutines means the loop now has to schedule and plan half the number of tasks, while the logic remains the same.

- Due to returning the Coroutines the following was changed:
  - _await_ __wait_hello_from_server__ now returns __Literal[True]__ instead of __None__
  - _await_ __wait_for_idle_response__ didn't have a return type, but now returns __Literal[True]__

### Test was altered, why?
- It also failed in the main branch, I didn't really investigate but it seams odd that it would be off by 2.