### PR TITLE
replace incorrect 'Pattern' typehint with 'str'

### DIFF
--- a/aioimaplib/aioimaplib.py
+++ b/aioimaplib/aioimaplib.py
@@ -28,7 +28,7 @@ from collections import namedtuple
 from copy import copy
 from datetime import datetime, timezone, timedelta
 from enum import Enum
-from typing import Union, Any, Coroutine, Callable, Optional, Pattern, List
+from typing import Union, Any, Coroutine, Callable, Optional, List
 
 # to avoid imap servers to kill the connection after 30mn idling
 # cf https://www.imapwiki.org/ClientImplementation/Synchronization
@@ -620,7 +620,7 @@ class IMAP4ClientProtocol(asyncio.Protocol):
     async def wait_async_pending_commands(self) -> None:
         await asyncio.wait([asyncio.ensure_future(cmd.wait()) for cmd in self.pending_async_commands.values()])
 
-    async def wait(self, state_regexp: Pattern) -> None:
+    async def wait(self, state_regexp: str) -> None:
         state_re = re.compile(state_regexp)
         async with self.state_condition:
             await self.state_condition.wait_for(lambda: state_re.match(self.state))
@@ -840,7 +840,7 @@ class IMAP4:
     async def getquotaroot(self, mailbox_name: str) -> Response:
         return await asyncio.wait_for(self.protocol.execute(Command('GETQUOTAROOT', self.protocol.new_tag(), 'INBOX', untagged_resp_name='QUOTA')), self.timeout)
 
-    async def list(self, reference_name: str, mailbox_pattern: Pattern) -> Response:
+    async def list(self, reference_name: str, mailbox_pattern: str) -> Response:
         return await asyncio.wait_for(self.protocol.simple_command('LIST', reference_name, mailbox_pattern), self.timeout)
 
     async def append(self, message_bytes, mailbox: str = 'INBOX', flags: str = None, date: Any = None) -> Response:


### PR DESCRIPTION
typing.Pattern is a deprecated alias since version 3.9 as per: https://docs.python.org/3/library/typing.html#typing.Pattern that was supposed to represent the return type of re.compile().

It was used in the definitions of IMAP4ClientProtocol.wait and IMAP4.list

In IMAP4.list I found out through manual testing that it expects a Literal, even though my linter bugged me about it due to the Pattern type hint.

In IMAP4ClientProtocol.wait the first line runs re.compile on the parameter that is type-hinted as Pattern, therefore it must also take a Literal and not a Pattern.

I think it would reduce confusion when using the module if we replaced these type hints with the correct types. Having them there doesn't necessarily make it so the code doesn't run, but it definitely took me some time to look and find out what was wrong that could be avoided by future users of the library.

Thanks & kind regards